### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "Template::Anti",
+    "license" : "Artistic-2.0",
     "version" : "0.4.0",
     "description" : "The anti-template templating tool.",
     "authors" : [ "Sterling Hanenkamp <hanenkamp@cpan.org>" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license